### PR TITLE
Added task execution functionality

### DIFF
--- a/jython_scripts/config.yaml
+++ b/jython_scripts/config.yaml
@@ -13,15 +13,3 @@ sys-dev2:
   user: "sa"
   password_envar: "SYBASEPASSWORD"
   database_name: "master"
-# oracle-dev:
-#   dbtype: ORACLE
-#   host: dboracle
-#   port: 1542
-#   user: system
-#   password_envar: ORACLEPASSWORD
-#   database_name: dev
-tasks: 
-  -  DumpTableToExcel
-  -  GetViewSchemaReference
-  -  GetProceSchemaReference
-

--- a/jython_scripts/config.yaml
+++ b/jython_scripts/config.yaml
@@ -1,12 +1,12 @@
 # Database Tasks
-sys-dev1:
+sys-dev:
   dbtype: "SYBASE"
   host: "dbsybase"
   port: "5000"
   user: "sa"
   password_envar: "SYBASEPASSWORD"
   database_name: "master"
-sys-dev2:
+sys-dev1:
   dbtype: "SYBASE"
   host: "dbsybase"
   port: "5000"

--- a/jython_scripts/dbdiff.py
+++ b/jython_scripts/dbdiff.py
@@ -1,5 +1,6 @@
 import sys
 import argparse
+import csv
 
 #JAVA ITEMS
 sys.path.append("/workspace/target/DbTest-jar-with-dependencies.jar")
@@ -8,12 +9,18 @@ import DbConn
 import DataUtils
 
 from objects.database import Database
+from objects.task import Task
 
 # Notes:
 # jython is python 2.7.1 
 # It doesn't support list comp
-SELECTQUERY = """SELECT c.text FROM sysusers u, syscomments c, sysobjects o 
-                WHERE o.type = 'P' AND o.id = c.id AND o.uid = u.uid  ORDER BY o.id, c.colid""";
+
+# Task:
+#   key : str
+#   e : str
+#   instruction : {instruction_key : operation }
+#       op_key = database_connection.key
+#       operation = sql/py to execute
 
 def readyaml(db_yaml, task_yaml):
     parser = YamlParser() # NOT THREAD SAFE
@@ -24,23 +31,27 @@ def readyaml(db_yaml, task_yaml):
     for key in parsed_db_yaml:
         database_objects.append(Database(parsed_db_yaml[key], key))
     for key in parsed_task_yaml:
-            tasks = [val for val in parsed_task_yaml[key]]
+        tasks.append(Task(parsed_task_yaml[key], key))
     return database_objects, tasks
 
+# Returns {database.key: conn}
 def create_db_connections(database_objects):
     databases_connections = {}
     for base in database_objects:
         baseConnection = DbConn.DbType.getMyEnumIfExists(base.dbtype)
         if baseConnection is not None:
             con = DbConn(baseConnection, base.user, base.password, base.host, base.port, base.database_name)
-            databases_connections[base] = con
+            databases_connections[base.key] = con
         else:
-            baseConnection[base] = None
+            baseConnection[base.key] = None
     return databases_connections
 
-def execute_sql_test_sysbase(db):
-    result = db.queryToList(SELECTQUERY)
-    print(result)
+def execute_sql_test_sysbase(connection, task):
+    if "sql" in task.keys():
+        result = connection.queryToList(task["sql"])
+        return result
+    else:
+        return "Operation not supported yet"
 
 def parse_cli():
     parser = argparse.ArgumentParser(description='Process a yaml file')
@@ -49,14 +60,44 @@ def parse_cli():
     args = parser.parse_args()
     return args 
 
+def task_execution(databases_connections, task_config):
+    output = {} # task.key: {instruction_key: output, instruction_key: output}
+    for task in task_config:
+        print("Running task: {0}".format(task.key))
+        if task.e:
+            print("\tError occured in the task: {0}".format(task.e))
+        else:
+            output[task.key] = {}
+            for instruction_key in task.instructions:
+                if instruction_key in databases_connections.keys():
+                    connection = databases_connections[instruction_key]
+                    res = execute_sql_test_sysbase(connection, task.instructions[instruction_key])
+                else:
+                    res = "Task {0} with key {1} not found".format(task.key, instruction_key)
+                output[task.key][instruction_key] = res
+    return output
+
+def export_results(rows, filename):
+    with open(filename, "w+") as csvfile:
+        writer = csv.writer(csvfile, delimiter=",")
+        writer.writerows(rows)
+
+def create_report(output):
+    print("\n-------Results-------")
+    for key in output:
+        print("Task: {0}".format(key))
+        for instruction in output[key]:
+            rows = output[key][instruction]
+            print("\t{0} results returned {1}".format(instruction, len(rows)))
+            if len(rows) > 0:
+                export_results(rows, "{0}-{1}.csv".format(key,instruction))
+
 def execute(args):
     db_config, task_config = readyaml(args.y, args.t)
-    databases_connections = create_db_connections(db_config) # dic
+    databases_connections = create_db_connections(db_config)
+    output = task_execution(databases_connections, task_config)
+    create_report(output)
 
-    print("\nConnection stats:")
-    print("\t{0} active connections:".format(len(databases_connections)))
-    for key in databases_connections:
-        print("\t\t{0} : {1}".format(key, databases_connections[key]))
 
 if __name__ == "__main__":
     args = parse_cli()

--- a/jython_scripts/dbdiff.py
+++ b/jython_scripts/dbdiff.py
@@ -15,35 +15,28 @@ from objects.database import Database
 SELECTQUERY = """SELECT c.text FROM sysusers u, syscomments c, sysobjects o 
                 WHERE o.type = 'P' AND o.id = c.id AND o.uid = u.uid  ORDER BY o.id, c.colid""";
 
-def readyaml(yaml):
+def readyaml(db_yaml, task_yaml):
     parser = YamlParser() # NOT THREAD SAFE
-    parsed_yaml = parser.ReadYAML(yaml)
+    parsed_db_yaml = parser.ReadYAML(db_yaml)
+    parsed_task_yaml = parser.ReadYAML(task_yaml)
 
-    print(parsed_yaml)
     database_objects, tasks = [], []
-    for key in parsed_yaml:
-        if key == "tasks":
-            tasks = [val for val in parsed_yaml[key]]
-        else:
-            database_objects.append(Database(parsed_yaml[key]))
-
-    print("\nDatabase objects found:")
-    for obj in database_objects:
-        print("\t{0}".format(str(obj)))
-
-    print("\nTasks found:")
-    for task in tasks:
-       print("\t{0}".format(task))
-    return database_objects
+    for key in parsed_db_yaml:
+        database_objects.append(Database(parsed_db_yaml[key], key))
+    for key in parsed_task_yaml:
+            tasks = [val for val in parsed_task_yaml[key]]
+    return database_objects, tasks
 
 def create_db_connections(database_objects):
-    connections = []
+    databases_connections = {}
     for base in database_objects:
         baseConnection = DbConn.DbType.getMyEnumIfExists(base.dbtype)
         if baseConnection is not None:
             con = DbConn(baseConnection, base.user, base.password, base.host, base.port, base.database_name)
-            connections.append(con)
-    return connections
+            databases_connections[base] = con
+        else:
+            baseConnection[base] = None
+    return databases_connections
 
 def execute_sql_test_sysbase(db):
     result = db.queryToList(SELECTQUERY)
@@ -51,18 +44,19 @@ def execute_sql_test_sysbase(db):
 
 def parse_cli():
     parser = argparse.ArgumentParser(description='Process a yaml file')
-    parser.add_argument("-y", help="Location of the yaml file")
+    parser.add_argument("-y", help="Location of the yaml file", required=True)
+    parser.add_argument("-t", help="Location of tasks folder", required=True)
     args = parser.parse_args()
     return args 
 
 def execute(args):
-    config = readyaml(args.y)
-    databases_connections = create_db_connections(config)
+    db_config, task_config = readyaml(args.y, args.t)
+    databases_connections = create_db_connections(db_config) # dic
 
     print("\nConnection stats:")
     print("\t{0} active connections:".format(len(databases_connections)))
-    for db in databases_connections:
-        print("\t\t{0}".format(db))
+    for key in databases_connections:
+        print("\t\t{0} : {1}".format(key, databases_connections[key]))
 
 if __name__ == "__main__":
     args = parse_cli()

--- a/jython_scripts/objects/database.py
+++ b/jython_scripts/objects/database.py
@@ -1,6 +1,7 @@
 import os
 
 class Database(object):
+    key = None
     dbtype = None
     host = None
     port = None
@@ -9,8 +10,9 @@ class Database(object):
     database_name = None
     password = None
 
-    def __init__(self, hashMap):
+    def __init__(self, hashMap, key):
         self._set_values(hashMap)
+        self.key = key
 
     def _set_values(self, hashMap):
         for entry in hashMap.entrySet():

--- a/jython_scripts/objects/task.py
+++ b/jython_scripts/objects/task.py
@@ -1,0 +1,21 @@
+class Task(object):
+    key = None
+    instructions = {}
+    e = None
+
+    def __init__(self, hashMap, key):
+        self._set_values(hashMap)
+        self.key = key
+
+    def _set_values(self, hashMap):
+        try:
+            for task in hashMap.entrySet():
+                operation = {}
+                for op_type in task.value.entrySet():
+                    operation[op_type.key] = op_type.value
+                self.instructions[task.key] = operation
+        except AttributeError as e:
+            self.e = "There are no instruction set or formatting is bad\n\tDetailed\n\t{0}".format(e)
+
+    def __repr__(self):
+        return str(self.__dict__)

--- a/jython_scripts/tasks.yaml
+++ b/jython_scripts/tasks.yaml
@@ -1,0 +1,7 @@
+DumpTableToExcel:
+  sys-dev:
+      sql: SELECT * FROM newauthors
+  sys-dev1:
+      sql: SELECT c.text FROM sysusers u, syscomments c, sysobjects o WHERE o.type = 'P' AND o.id = c.id AND o.uid = u.uid  ORDER BY o.id, c.colid
+GetViewSchemaReference:
+GetProceSchemaReference:


### PR DESCRIPTION
Added:
- Requires `-y` to point towards a `connections-config.yaml`
- Must now add `-t` during execution pointing toward a `task-config.yaml`
- Will execute `sql` defined in the `task.yaml`

Resolves #23 #21 